### PR TITLE
Add force push functionality for game saves

### DIFF
--- a/include/detailsViewWidget.h
+++ b/include/detailsViewWidget.h
@@ -18,6 +18,7 @@ class DetailsViewWidget : public QWidget {
 
   private slots:
     void forcePull();
+    void forcePush();
 
   private:
     int gameID = 0;
@@ -26,5 +27,7 @@ class DetailsViewWidget : public QWidget {
     QListView* pathList;
     QListWidget* executableList;
     QPushButton* forcePullButton;
+    QPushButton* forcePushButton;
     QFutureWatcher<void>* forcePullWatcher;
+    QFutureWatcher<void>* forcePushWatcher;
 };

--- a/include/utilGameSyncServer.h
+++ b/include/utilGameSyncServer.h
@@ -77,6 +77,7 @@ class UtilGameSyncServer {
     bool testConnection(QUrl testURL);
     std::expected<UtilGameSyncServer::GameSavesReturn, QString>
     fetchLastSaveFromServer(int pathId);
+    std::expected<void, QString> pushLocalSaveToServer(int pathId);
 
     UtilGameSyncServer(UtilGameSyncServer const&) = delete;
     UtilGameSyncServer& operator=(UtilGameSyncServer const&) = delete;

--- a/src/backgroundSyncWorker.cpp
+++ b/src/backgroundSyncWorker.cpp
@@ -90,22 +90,19 @@ void forEachGamePath(
 
 void BackgroundSyncWorker::syncGameSaveToServer() {
     for (int gameId : config::returnAllIds()) {
-        forEachGamePath(
-            gameId, [&](int pathId, const QString& configPath) -> void {
-                QMutexLocker locker(
-                    &Status::getInstance().getLockedPathIdMutex(pathId));
+        forEachGamePath(gameId, [&](int pathId, const QString&) -> void {
+            QMutexLocker locker(
+                &Status::getInstance().getLockedPathIdMutex(pathId));
 
-                if (!shouldUploadLocalFile(pathId))
-                    return;
+            if (!shouldUploadLocalFile(pathId))
+                return;
 
-                auto hashes =
-                    utilFileSystem::createZipForUpload(pathId, configPath);
-                if (auto uuid = UtilGameSyncServer::getInstance()
-                                    .postGameSavesForPathId(pathId, hashes);
-                    uuid.has_value()) {
-                    config::updateUUIDForPath(pathId, uuid.value());
-                }
-            });
+            std::expected<void, QString> result =
+                UtilGameSyncServer::getInstance().pushLocalSaveToServer(pathId);
+            if (!result.has_value())
+                qWarning() << "Error while sync Game Save to Server : " +
+                                  result.error();
+        });
     }
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -57,13 +57,12 @@ QString getPath(int pathID) {
 
 QString getUUIDForPath(int pathID) {
     QSettings settings = config::getConfig();
-    return settings.value(getPathUUIDKey(pathID) + "/last_save", QString{})
-        .toString();
+    return settings.value(getPathUUIDKey(pathID), QString{}).toString();
 }
 
 void updateUUIDForPath(int pathID, QString uuid) {
     QSettings settings = config::getConfig();
-    settings.setValue(getPathUUIDKey(pathID) + "/last_save", uuid);
+    settings.setValue(getPathUUIDKey(pathID), uuid);
 }
 
 void removeUUIDForPath(int pathID) {

--- a/src/detailsViewWidget.cpp
+++ b/src/detailsViewWidget.cpp
@@ -25,8 +25,17 @@ DetailsViewWidget::DetailsViewWidget(QWidget* parent) : QWidget(parent) {
     forcePullWatcher = new QFutureWatcher<void>(this);
     connect(forcePullWatcher, &QFutureWatcher<void>::finished, this,
             [this]() -> void { forcePullButton->setEnabled(true); });
+    forcePushButton = new QPushButton("Force Push");
+    forcePushButton->setToolTip(
+        "Delete remote save content and replace it with the local save");
+    connect(forcePushButton, &QPushButton::clicked, this,
+            &DetailsViewWidget::forcePush);
+    forcePushWatcher = new QFutureWatcher<void>(this);
+    connect(forcePushWatcher, &QFutureWatcher<void>::finished, this,
+            [this]() -> void { forcePushButton->setEnabled(true); });
     pathButtonLayout->addStretch();
     pathButtonLayout->addWidget(forcePullButton);
+    pathButtonLayout->addWidget(forcePushButton);
     executableList = new QListWidget(this);
 
     mainLayout->addWidget(gameNameLabel);
@@ -92,4 +101,33 @@ void DetailsViewWidget::forcePull() {
     });
 
     forcePullWatcher->setFuture(future);
+}
+
+void DetailsViewWidget::forcePush() {
+    if (gameID == 0) {
+        return;
+    }
+
+    std::optional<QList<UtilGameSyncServer::GamePath>> maybePathList =
+        UtilGameSyncServer::getInstance().getPathByGameId(gameID, true);
+
+    if (!maybePathList.has_value())
+        return;
+
+    forcePushButton->setEnabled(false);
+
+    QFuture<void> future = QtConcurrent::run([maybePathList]() -> void {
+        for (UtilGameSyncServer::GamePath path : maybePathList.value()) {
+            QMutexLocker locker(
+                &Status::getInstance().getLockedPathIdMutex(path.id));
+            std::expected<void, QString> result =
+                UtilGameSyncServer::getInstance().pushLocalSaveToServer(
+                    path.id);
+            if (!result.has_value())
+                qWarning() << "Error while sync Game Save to Server : " +
+                                  result.error();
+        }
+    });
+
+    forcePushWatcher->setFuture(future);
 }

--- a/src/utilGameSyncServer.cpp
+++ b/src/utilGameSyncServer.cpp
@@ -339,3 +339,15 @@ UtilGameSyncServer::fetchLastSaveFromServer(int pathId) {
                 return std::unexpected(error);
             });
 }
+
+std::expected<void, QString>
+UtilGameSyncServer::pushLocalSaveToServer(int pathId) {
+    auto hashes =
+        utilFileSystem::createZipForUpload(pathId, config::getPath(pathId));
+    auto uuid = UtilGameSyncServer::getInstance().postGameSavesForPathId(
+        pathId, hashes);
+    if (!uuid.has_value())
+        return std::unexpected<QString>{"failed to post game save"};
+    config::updateUUIDForPath(pathId, uuid.value());
+    return std::expected<void, QString>{};
+}


### PR DESCRIPTION
Add new methods and UI elements to support pushing local game saves to the server, including a new button and associated signal/slot connections. Modify the sync logic to use the new push method.