### PR TITLE
Suppress unused function warnings for miniz_static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,12 @@ target_include_directories(miniz_static
     PUBLIC SYSTEM "${miniz_SOURCE_DIR}"
 )
 
+target_compile_options(miniz_static INTERFACE
+  $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-function>
+  $<$<CXX_COMPILER_ID:GNU>:-Wno-unused-function>
+  $<$<CXX_COMPILER_ID:MSVC>:/wd4505>
+)
+
 if(MSVC)
     target_compile_options(miniz_static PRIVATE /W0)
 else()

--- a/src/utilFileSystem.cpp
+++ b/src/utilFileSystem.cpp
@@ -1,30 +1,12 @@
 #include "utilFileSystem.h"
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#include <miniz.h>
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#include <miniz.h>
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4505)
-#include <miniz.h>
-#pragma warning(pop)
-#else
-#include <miniz.h>
-#endif
-
 #include <QCryptographicHash>
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QMutexLocker>
 #include <QStandardPaths>
+#include <miniz.h>
 
 namespace utilFileSystem {
 bool validatePath(const QString path) { return !getBasePath(path).isEmpty(); }


### PR DESCRIPTION
Add INTERFACE compile options for Clang, GCC, MSVC to silence -Wunused-function warnings. Removed compiler-specific pragmas around miniz.h include in utilFileSystem.cpp. close #36 