### PR TITLE
Add stop to BackgroundSyncWorker and unlock wait

### DIFF
--- a/src/backgroundSyncWorker.cpp
+++ b/src/backgroundSyncWorker.cpp
@@ -10,11 +10,11 @@ constexpr int timerInterval = 30 * 1000;
 constexpr qint64 savesMinimumInterval = static_cast<qint64>(5 * 60);
 
 void BackgroundSyncWorker::start() {
-    auto timer = new QTimer(this);
-    connect(timer, &QTimer::timeout, this, &BackgroundSyncWorker::update);
+    backgroundTimer = new QTimer(this);
+    connect(backgroundTimer, &QTimer::timeout, this, &BackgroundSyncWorker::update);
     update();
-    timer->setInterval(timerInterval);
-    timer->start();
+    backgroundTimer->setInterval(timerInterval);
+    backgroundTimer->start();
 }
 
 std::expected<bool, GameSaveSyncError::Error> shouldUploadLocalFile(int pathId) {
@@ -234,4 +234,9 @@ void BackgroundSyncWorker::update() {
         emit errorOccurred(GameSaveSyncError::Error{.type = GameSaveSyncError::Other,
                                                     .message = QString::fromStdString(e.what())});
     }
+}
+
+void BackgroundSyncWorker::stop() {
+    QMetaObject::invokeMethod(
+        backgroundTimer, [&]() -> void { this->backgroundTimer->stop(); }, Qt::QueuedConnection);
 }

--- a/src/backgroundSyncWorker.h
+++ b/src/backgroundSyncWorker.h
@@ -16,12 +16,14 @@ class BackgroundSyncWorker : public QObject {
   public slots:
     void start();
     void update();
+    void stop();
 
   signals:
     void syncFinished();
     void errorOccurred(GameSaveSyncError::Error);
 
   private:
+    QTimer* backgroundTimer;
     void validatePaths();
     std::expected<void, GameSaveSyncError::Error> syncGameSaveToServer();
     std::expected<void, GameSaveSyncError::Error> syncGameSaveFromServer();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,9 @@
 #include "config.h"
 #include "mainWindow.h"
 #include "setupWindow.h"
+#include "status.h"
 #include <QApplication>
+#include <QElapsedTimer>
 #include <QThread>
 
 int main(int argc, char* argv[]) {
@@ -37,6 +39,18 @@ int main(int argc, char* argv[]) {
     mainWindow->show();
 
     int ret = app.exec();
+
+    worker->stop();
+
+    QElapsedTimer timer;
+    timer.start();
+    constexpr int timeoutMs = 10'000 * 10;
+    while (!Status::getInstance().allUnlockedPathId() && timer.elapsed() < timeoutMs) {
+        QThread::msleep(10);
+    }
+    if (timer.elapsed() >= timeoutMs) {
+        qWarning() << "Timeout while waiting for all path IDs to unlock.";
+    }
 
     worker->deleteLater();
     workerThread->deleteLater();

--- a/src/status.h
+++ b/src/status.h
@@ -36,6 +36,16 @@ class Status : public QObject {
         return *lockedPathId[id];
     }
 
+    bool allUnlockedPathId() {
+        QReadLocker lock(&rwLock);
+        for (auto* mutex : lockedPathId) {
+            if (!mutex->try_lock())
+                return false;
+            mutex->unlock();
+        }
+        return true;
+    }
+
   protected:
     Status() : QObject() {}
     ~Status() override { qDeleteAll(lockedPathId); }


### PR DESCRIPTION
Adds a stop() method to BackgroundSyncWorker that stops the background timer via a queued connection. Main.cpp now calls worker->stop() before cleanup and waits until all path IDs are unlocked using Status::allUnlockedPathId. to avoid race conditions during shutdown. close #33 