### PR TITLE
Add license info and third‑party dialog to About

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,13 @@ qt_add_resources(${TARGET_NAME} "icons"
         res/icon/GameSaveSyncClientTray.svg
 )
 
+qt_add_resources(${TARGET_NAME} "license"
+    PREFIX "/"
+    FILES
+        res/license/LICENSE.txt
+        res/license/Third-Party.txt
+)
+
 target_compile_definitions(${TARGET_NAME} PRIVATE
   $<$<CONFIG:Debug>:DEBUG QT_DEBUG>
   $<$<CONFIG:Release>:NDEBUG>

--- a/res/license/LICENSE.txt
+++ b/res/license/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jonathan Croteau-Dicaire
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/res/license/Third-Party.txt
+++ b/res/license/Third-Party.txt
@@ -1,0 +1,22 @@
+Copyright 2013-2014 RAD Game Tools and Valve Software
+Copyright 2010-2014 Rich Geldreich and Tenacious Software LLC
+
+All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/aboutDialog.cpp
+++ b/src/aboutDialog.cpp
@@ -12,10 +12,14 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent) {
     layout->setContentsMargins(12, 12, 12, 12);
     layout->setSpacing(14);
 
+    auto* logoLayout = new QHBoxLayout();
     auto* logoSvgWidget = new QSvgWidget(":/res/icon/GameSaveSyncClient.svg");
     logoSvgWidget->renderer()->setAspectRatioMode(Qt::KeepAspectRatio);
-    logoSvgWidget->setSizePolicy({QSizePolicy::Maximum, QSizePolicy::Preferred});
-    layout->addWidget(logoSvgWidget, Qt::AlignCenter);
+    logoSvgWidget->setFixedSize(200, 200);
+    logoLayout->addStretch();
+    logoLayout->addWidget(logoSvgWidget);
+    logoLayout->addStretch();
+    layout->addLayout(logoLayout);
 
     QString applicationName = QCoreApplication::applicationName();
     auto* applicationLabel = new QLabel(applicationName);
@@ -27,20 +31,59 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent) {
     versionLabel->setAlignment(Qt::AlignCenter);
     layout->addWidget(versionLabel);
 
-    auto* licenseLabel = new QLabel(QStringLiteral("License: MIT"));
+    auto* licenseLabel = new QLabel();
+
+    QFile licenseFile(":/res/license/LICENSE.txt");
+    if (!licenseFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        licenseLabel->setText("License information not available.");
+    } else {
+        QTextStream stream(&licenseFile);
+        stream.setEncoding(QStringConverter::Utf8);
+        licenseLabel->setText(stream.readAll());
+    }
+
     licenseLabel->setAlignment(Qt::AlignCenter);
     layout->addWidget(licenseLabel);
+
+    auto* thirdPartyButton = new QPushButton(tr("Third‑Party Licenses"), this);
+    connect(thirdPartyButton, &QPushButton::clicked, this, [this]() -> void {
+        QFile file(":/res/license/Third-Party.txt");
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            QMessageBox::warning(this, tr("Error"), tr("Could not open third‑party license file."));
+            return;
+        }
+        QTextStream stream(&file);
+        stream.setEncoding(QStringConverter::Utf8);
+        QString text = stream.readAll();
+
+        QDialog thirdPartyDialog(this);
+        thirdPartyDialog.setWindowTitle(tr("Third‑Party Licenses"));
+        auto* dialogLayout = new QVBoxLayout(&thirdPartyDialog);
+
+        auto* txt = new QTextEdit(&thirdPartyDialog);
+        txt->setReadOnly(true);
+        txt->setPlainText(text);
+        dialogLayout->addWidget(txt);
+
+        auto* btnBox = new QDialogButtonBox(QDialogButtonBox::Ok, this);
+        connect(btnBox, &QDialogButtonBox::accepted, &thirdPartyDialog, &QDialog::accept);
+        dialogLayout->addWidget(btnBox);
+
+        thirdPartyDialog.resize(600, 500);
+        thirdPartyDialog.exec();
+    });
 
     auto* buttonLayout = new QHBoxLayout();
     auto* closeButton = new QPushButton("Ok");
     connect(closeButton, &QPushButton::clicked, this, [&]() -> void { this->close(); });
     buttonLayout->addStretch();
+    buttonLayout->addWidget(thirdPartyButton);
     buttonLayout->addWidget(closeButton);
     layout->addLayout(buttonLayout);
 
     setLayout(layout);
 
     this->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    this->setMinimumSize({250, 300});
-    this->setMaximumSize({250, 300});
+    this->setMinimumSize({650, 750});
+    this->setMaximumSize({650, 750});
 }


### PR DESCRIPTION
Include license files in resources and show them in AboutDialog. Add button to view third‑party licenses. Update logo layout and dialog size.