### PR TITLE
Add start/stop support for BackgroundSyncWorker

### DIFF
--- a/src/backgroundSyncWorker.cpp
+++ b/src/backgroundSyncWorker.cpp
@@ -9,12 +9,20 @@
 constexpr int timerInterval = 30 * 1000;
 constexpr qint64 savesMinimumInterval = static_cast<qint64>(5 * 60);
 
-void BackgroundSyncWorker::start() {
+BackgroundSyncWorker::BackgroundSyncWorker(QObject* parent) : QObject(parent) {
     backgroundTimer = new QTimer(this);
     connect(backgroundTimer, &QTimer::timeout, this, &BackgroundSyncWorker::update);
-    update();
-    backgroundTimer->setInterval(timerInterval);
-    backgroundTimer->start();
+}
+
+void BackgroundSyncWorker::start() {
+    QMetaObject::invokeMethod(
+        backgroundTimer,
+        [&]() -> void {
+            update();
+            backgroundTimer->setInterval(timerInterval);
+            backgroundTimer->start();
+        },
+        Qt::QueuedConnection);
 }
 
 std::expected<bool, GameSaveSyncError::Error> shouldUploadLocalFile(int pathId) {
@@ -245,4 +253,12 @@ void BackgroundSyncWorker::update() {
 void BackgroundSyncWorker::stop() {
     QMetaObject::invokeMethod(
         backgroundTimer, [&]() -> void { this->backgroundTimer->stop(); }, Qt::QueuedConnection);
+}
+
+bool BackgroundSyncWorker::isRunning() {
+    if (backgroundTimer != nullptr) {
+        return backgroundTimer->isActive();
+    } else {
+        return false;
+    }
 }

--- a/src/backgroundSyncWorker.h
+++ b/src/backgroundSyncWorker.h
@@ -11,7 +11,8 @@ class BackgroundSyncWorker : public QObject {
     Q_OBJECT
 
   public:
-    BackgroundSyncWorker(QObject* parent = nullptr) : QObject(parent) {}
+    BackgroundSyncWorker(QObject* parent = nullptr);
+    bool isRunning();
 
   public slots:
     void start();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,10 +38,11 @@ int main(int argc, char* argv[]) {
             return 0;
     }
 
-    auto workerThread = new QThread;
-    auto worker = new BackgroundSyncWorker;
-    worker->moveToThread(workerThread);
-    QObject::connect(workerThread, &QThread::started, worker, &BackgroundSyncWorker::start);
+    auto backgroundWorkerThread = new QThread;
+    auto backgroundWorker = new BackgroundSyncWorker;
+    backgroundWorker->moveToThread(backgroundWorkerThread);
+    QObject::connect(backgroundWorkerThread, &QThread::started, backgroundWorker,
+                     &BackgroundSyncWorker::start);
 
     QLocalSocket probeSocket;
     probeSocket.connectToServer(BackgroundServerWorker::serverName.toString());
@@ -52,18 +53,20 @@ int main(int argc, char* argv[]) {
     probeSocket.disconnectFromServer();
     auto serverThread = new QThread;
     auto* serverWorker = new BackgroundServerWorker();
-    serverWorker->moveToThread(workerThread);
+    serverWorker->moveToThread(backgroundWorkerThread);
     QObject::connect(serverThread, &QThread::started, serverWorker, &BackgroundServerWorker::start);
 
-    auto mainWindow = new MainWindow;
+    auto mainWindow = new MainWindow(backgroundWorker);
 
     auto trayIcon = new TrayIcon();
     trayIcon->addShowMenuItem(mainWindow);
     trayIcon->addShowSetupItem();
     trayIcon->addSeparator();
+    trayIcon->addStartStopItem(backgroundWorker);
+    trayIcon->addSeparator();
     trayIcon->addQuitMenuItem();
 
-    workerThread->start();
+    backgroundWorkerThread->start();
     serverThread->start();
 
     if (!parser.isSet(minimizedOption)) {
@@ -71,7 +74,7 @@ int main(int argc, char* argv[]) {
     }
     int ret = app.exec();
 
-    worker->stop();
+    backgroundWorker->stop();
     serverWorker->stop();
 
     QElapsedTimer timer;
@@ -84,10 +87,11 @@ int main(int argc, char* argv[]) {
         qWarning() << "Timeout while waiting for all path IDs to unlock.";
     }
 
+    trayIcon->deleteLater();
     serverWorker->deleteLater();
     serverThread->deleteLater();
-    worker->deleteLater();
-    workerThread->deleteLater();
+    backgroundWorker->deleteLater();
+    backgroundWorkerThread->deleteLater();
 
     return ret;
 }

--- a/src/mainWindow.cpp
+++ b/src/mainWindow.cpp
@@ -20,7 +20,10 @@
 #include <QtLogging>
 #include <algorithm>
 
-MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
+MainWindow::MainWindow(BackgroundSyncWorker* backgroundWorker, QWidget* parent)
+    : QMainWindow(parent) {
+    this->backgroundWorker = backgroundWorker;
+
     mainMenuBar = new QMenuBar(this);
 
     fileMenu = mainMenuBar->addMenu("&File");
@@ -48,6 +51,36 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent) {
     removeGameFromSyncAction->setStatusTip("Remove a game from the sync list");
     connect(removeGameFromSyncAction, &QAction::triggered, this, &MainWindow::removeGameFromSync);
     syncMenu->addAction(removeGameFromSyncAction);
+
+    syncMenu->addSeparator();
+
+    startSyncAction =
+        new QAction(QIcon::fromTheme(QIcon::ThemeIcon::MediaPlaybackStart), "R&esume sync");
+    startSyncAction->setStatusTip("Resume the background sync");
+    connect(startSyncAction, &QAction::triggered, this, [&]() -> void {
+        if (!this->backgroundWorker->isRunning()) {
+            this->backgroundWorker->start();
+        }
+    });
+    stopSyncAction =
+        new QAction(QIcon::fromTheme(QIcon::ThemeIcon::MediaPlaybackPause), "&Pause sync");
+    stopSyncAction->setStatusTip("Pause the background sync");
+    connect(stopSyncAction, &QAction::triggered, this, [&]() -> void {
+        if (this->backgroundWorker->isRunning()) {
+            this->backgroundWorker->stop();
+        }
+    });
+
+    connect(syncMenu, &QMenu::aboutToShow, this, [&]() -> void {
+        if (this->backgroundWorker->isRunning()) {
+            startSyncAction->setEnabled(false);
+            stopSyncAction->setEnabled(true);
+        } else {
+            startSyncAction->setEnabled(true);
+            stopSyncAction->setEnabled(false);
+        }
+    });
+    syncMenu->addActions({startSyncAction, stopSyncAction});
 
     aboutMenu = mainMenuBar->addMenu("&About");
     aboutDialogAction = new QAction(QIcon::fromTheme(QIcon::ThemeIcon::HelpAbout), "&About", this);

--- a/src/mainWindow.h
+++ b/src/mainWindow.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "backgroundSyncWorker.h"
 #include "detailsViewWidget.h"
 #include <QAction>
 #include <QCloseEvent>
@@ -17,7 +18,7 @@ class MainWindow : public QMainWindow {
     Q_OBJECT
 
   public:
-    MainWindow(QWidget* parent = nullptr);
+    MainWindow(BackgroundSyncWorker* worker, QWidget* parent = nullptr);
     ~MainWindow() override = default;
 
   public slots:
@@ -30,6 +31,7 @@ class MainWindow : public QMainWindow {
     void closeEvent(QCloseEvent* event) override;
 
   private:
+    BackgroundSyncWorker* backgroundWorker;
     DetailsViewWidget* detailsView;
     QAction* aboutDialogAction;
     QAction* aboutQtAction;
@@ -37,6 +39,8 @@ class MainWindow : public QMainWindow {
     QAction* quitAction;
     QAction* removeGameFromSyncAction;
     QAction* showSetupWindowAction;
+    QAction* startSyncAction;
+    QAction* stopSyncAction;
     QListWidget* syncList;
     QMenu* aboutMenu;
     QMenu* fileMenu;

--- a/src/trayIcon.cpp
+++ b/src/trayIcon.cpp
@@ -15,20 +15,20 @@ TrayIcon::TrayIcon() {
 }
 
 void TrayIcon::addShowMenuItem(MainWindow* mainWindow) {
-    showMainWindowAction = new QAction("Show");
+    auto showMainWindowAction = new QAction("Show");
     trayMenu->addAction(showMainWindowAction);
     connect(showMainWindowAction, &QAction::triggered, mainWindow, &MainWindow::showWindow);
 
     connect(trayIcon, &QSystemTrayIcon::activated, this,
-            [&](QSystemTrayIcon::ActivationReason reason) -> void {
+            [=](QSystemTrayIcon::ActivationReason reason) -> void {
                 if (reason == QSystemTrayIcon::Trigger) {
-                    this->showMainWindowAction->trigger();
+                    showMainWindowAction->trigger();
                 }
             });
 };
 
 void TrayIcon::addQuitMenuItem() {
-    quitAction = new QAction("Quit");
+    auto quitAction = new QAction("Quit");
     connect(quitAction, &QAction::triggered, qApp, &QApplication::quit);
     trayMenu->addAction(quitAction);
 }
@@ -36,7 +36,7 @@ void TrayIcon::addQuitMenuItem() {
 void TrayIcon::addSeparator() { trayMenu->addSeparator(); }
 
 void TrayIcon::addShowSetupItem() {
-    showSetupAction = new QAction("Setup");
+    auto showSetupAction = new QAction("Setup");
     trayMenu->addAction(showSetupAction);
 
     connect(showSetupAction, &QAction::triggered, this, []() -> void {
@@ -44,4 +44,35 @@ void TrayIcon::addShowSetupItem() {
         setupWindowDialog->setAttribute(Qt::WA_DeleteOnClose);
         setupWindowDialog->show();
     });
+}
+
+void TrayIcon::addStartStopItem(BackgroundSyncWorker* backgroundSyncWorker) {
+    this->backgroundSyncWorker = backgroundSyncWorker;
+
+    startBackgroundSyncAction = new QAction("Resume Sync");
+    stopBackgroundSyncAction = new QAction("Pause Sync");
+
+    connect(startBackgroundSyncAction, &QAction::triggered, this->backgroundSyncWorker,
+            &BackgroundSyncWorker::start);
+    connect(stopBackgroundSyncAction, &QAction::triggered, this->backgroundSyncWorker,
+            &BackgroundSyncWorker::stop);
+
+    trayMenu->addAction(startBackgroundSyncAction);
+    trayMenu->addAction(stopBackgroundSyncAction);
+
+    updateSyncActions();
+
+    connect(trayMenu, &QMenu::aboutToShow, this, &TrayIcon::updateSyncActions);
+}
+
+void TrayIcon::updateSyncActions() {
+    if (!backgroundSyncWorker) {
+        startBackgroundSyncAction->setVisible(false);
+        stopBackgroundSyncAction->setVisible(false);
+        return;
+    }
+
+    bool running = backgroundSyncWorker->isRunning();
+    startBackgroundSyncAction->setVisible(!running);
+    stopBackgroundSyncAction->setVisible(running);
 }

--- a/src/trayIcon.h
+++ b/src/trayIcon.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "backgroundSyncWorker.h"
 #include "mainWindow.h"
 #include <QAction>
 #include <QSystemTrayIcon>
@@ -10,12 +11,15 @@ class TrayIcon : public QObject {
     void addShowMenuItem(MainWindow* mainWindow);
     void addShowSetupItem();
     void addQuitMenuItem();
+    void addStartStopItem(BackgroundSyncWorker* backgroundSyncWorker);
     void addSeparator();
 
   private:
     QSystemTrayIcon* trayIcon;
     QMenu* trayMenu;
-    QAction* showMainWindowAction;
-    QAction* showSetupAction;
-    QAction* quitAction;
+    BackgroundSyncWorker* backgroundSyncWorker;
+    QAction* startBackgroundSyncAction;
+    QAction* stopBackgroundSyncAction;
+
+    void updateSyncActions();
 };


### PR DESCRIPTION
close #57 
Add isRunning() method to query timer status. Refactor start() to invoke update() and timer start via queued connection. Update MainWindow to accept worker and add resume/pause sync actions. Add TrayIcon start/stop actions and dynamic visibility. Update main.cpp to use new worker constructor and thread names.